### PR TITLE
Allow user lookup by apikey

### DIFF
--- a/octoprint_auth_ldap/__init__.py
+++ b/octoprint_auth_ldap/__init__.py
@@ -50,8 +50,8 @@ class LDAPUserManager(FilebasedUserManager,
         if FilebasedUserManager.findUser(self, username) is not None:
             return FilebasedUserManager.changeUserPassword(self, username, password)
 
-    def findUser(self, userid=None, session=None):
-        local_user = FilebasedUserManager.findUser(self, userid, session)
+    def findUser(self, userid=None, apikey=None, session=None):
+        local_user = FilebasedUserManager.findUser(self, userid, apikey, session)
         #If user not exists in local database, search it on LDAP
         if userid and not local_user:
             if(self.findLDAPUser(userid)):


### PR DESCRIPTION
This plugin breaks the GCode Viewer as is. When using this plugin and accessing the GCode Viewer, one gets this error in the log:

`TypeError: findUser() got an unexpected keyword argument 'apikey'`

This commit ensures that the findUser function knows how to handle the 'apikey' parameter from ~/octoprint/server/util/__init__.py if submitted.

DETAILED LOG MESSAGE:
```2019-02-08 00:21:49,019 - tornado.application - ERROR - Uncaught exception GET /downloads/files/local/PI_balanced_die_version_2_rotated_PLA.gcode (192.168.0.6)
Traceback (most recent call last):
  File "/opt/octoprint/OctoPrint/venv/local/lib/python2.7/site-packages/tornado-4.5.3-py2.7-linux-armv7l.egg/tornado/web.py", line 1510, in _execute
    result = method(*self.path_args, **self.path_kwargs)
  File "/opt/octoprint/OctoPrint/venv/local/lib/python2.7/site-packages/OctoPrint-1.3.10-py2.7.egg/octoprint/server/util/tornado.py", line 918, in get
    self._access_validation(self.request)
  File "/opt/octoprint/OctoPrint/venv/local/lib/python2.7/site-packages/OctoPrint-1.3.10-py2.7.egg/octoprint/server/util/tornado.py", line 1175, in f
    validator(request)
  File "/opt/octoprint/OctoPrint/venv/local/lib/python2.7/site-packages/OctoPrint-1.3.10-py2.7.egg/octoprint/server/util/tornado.py", line 1156, in f
    validator(flask.request)
  File "/opt/octoprint/OctoPrint/venv/lib/python2.7/site-packages/OctoPrint-1.3.10-py2.7.egg/octoprint/plugins/forcelogin/__init__.py", line 121, in access_validator
    user = get_flask_user_from_request(request)
  File "/opt/octoprint/OctoPrint/venv/local/lib/python2.7/site-packages/OctoPrint-1.3.10-py2.7.egg/octoprint/server/util/flask.py", line 1113, in get_flask_user_from_request
    user = octoprint.server.util.get_user_for_apikey(apikey)
  File "/opt/octoprint/OctoPrint/venv/local/lib/python2.7/site-packages/OctoPrint-1.3.10-py2.7.egg/octoprint/server/util/__init__.py", line 189, in get_user_for_apikey
    user = octoprint.server.userManager.findUser(apikey=apikey)
TypeError: findUser() got an unexpected keyword argument 'apikey'
2019-02-08 00:21:49,026 - tornado.access - ERROR - 500 GET /downloads/files/local/PI_balanced_die_version_2_rotated_PLA.gcode (192.168.0.6) 23.91ms
```
