### PR TITLE
Added a few changes to the plugin to be compatible with the new octoprint versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If installing on Windows, you will need to find the proper pre-built binary of p
 You can install this via the OctoPrint plugin manager GUI using this URL:
 
 ```
-https://github.com/battis/OctoPrint-LDAP/archive/master.zip
+https://github.com/gillg/OctoPrint-LDAP/archive/refs/heads/master.zip
 ```
 
 The plugin may also be installed within the oprint venv using the command

--- a/octoprint_auth_ldap/group_manager.py
+++ b/octoprint_auth_ldap/group_manager.py
@@ -151,6 +151,7 @@ class LDAPGroupManager(FilebasedGroupManager, DependentOnSettingsPlugin, Depende
             try:
                 with io.open(self._groupfile, 'rt', encoding='utf-8') as f:
                     data = yaml.safe_load(f)
+                    version = data.pop("_version", 1)
 
                 if "groups" not in data:
                     groups = data

--- a/octoprint_auth_ldap/user.py
+++ b/octoprint_auth_ldap/user.py
@@ -11,6 +11,7 @@ class LDAPUser(User):
     def __init__(
             self,
             username,
+            passwordHash=None,
             active=True,
             permissions=None,
             groups=None,
@@ -21,7 +22,7 @@ class LDAPUser(User):
         User.__init__(
             self,
             username=username,
-            passwordHash=None,
+            passwordHash=passwordHash,
             active=active,
             permissions=permissions,
             groups=groups,

--- a/octoprint_auth_ldap/user_manager.py
+++ b/octoprint_auth_ldap/user_manager.py
@@ -137,6 +137,7 @@ class LDAPUserManager(FilebasedUserManager, DependentOnSettingsPlugin, Dependent
                 self.logger.debug("%s was %sauthenticated" % (user.get_name(), "" if authenticated else "not "))
                 if authenticated:
                     user._passwordHash = LDAPUserManager.create_password_hash(password, settings=self._settings)
+                    self._save(force=True)
                 return authenticated
             else:
                 self.logger.debug("%s is inactive or no longer a member of required groups" % user.get_id())
@@ -187,6 +188,7 @@ class LDAPUserManager(FilebasedUserManager, DependentOnSettingsPlugin, Dependent
                         self.logger.debug("Loading %s as %s" % (name, LDAPUser.__name__))
                         self._users[name] = LDAPUser(
                             username=name,
+                            passwordHash=attributes["password"],
                             active=attributes["active"],
                             permissions=permissions,
                             groups=groups,
@@ -234,7 +236,7 @@ class LDAPUserManager(FilebasedUserManager, DependentOnSettingsPlugin, Dependent
                     # password field has to exist because of how FilebasedUserManager processes
                     # data, but an empty password hash cannot match any entered password (as
                     # whatever the user enters will be hashed... even an empty password.
-                    "password": None,
+                    "password": user._passwordHash,
 
                     "active": user._active,
                     "groups": self._from_groups(*user._groups),


### PR DESCRIPTION
Hi,
added a few changes to the plugin to be compatible with the new octoprint versions >1.8.4
- Check for added settings version with pop to remove from dict.
- passwordHash for users added to fulfill signature_key_for_user check.
- passwordHash is generated after each successful LDAP check with the used password.
- Added fresh parameter for find_user function to ensure compatibility.

Tested with version 1.8.6