### PR TITLE
add password file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,19 @@ plugins:
     auth_password: s00p3rS3KRE7
 ```
 
+Alternatively you can use `auth_password_file` to avoid keeping the password in
+your configuration file.  Be mindful of line breaks in your password file.  An
+end-of-line at the end of the file will place a line break in the password
+submitted to LDAP.  Also ensure the Octoprint user has permission to read the
+file.
+
+```YAML
+plugins:
+  auth_ldap:
+    auth_user: example\authuser
+    auth_password_file: /path/to/password/file
+```
+
 If no authentication username is provided, an anonymous search will be performed (which may not generate useful results on most servers). The `auth_user` can be provided as a distinguished name (`uid=authuser,dc=example,dc=com`), principal name (`authuser@example.com`) or UID (`example\authuser`), depending on the needs of the system.
 
 #### Default Roles/Activity

--- a/octoprint_auth_ldap/constants.py
+++ b/octoprint_auth_ldap/constants.py
@@ -3,6 +3,7 @@
 # settings keys
 # DO NOT CHANGE without updating AuthLDAPPlugin.on_settings_migrate()
 AUTH_PASSWORD = "auth_password"
+AUTH_PASSWORD_FILE = "auth_password_file"
 AUTH_USER = "auth_user"
 DEFAULT_ADMIN_GROUP = "default_admin_group"
 DEFAULT_USER_GROUP = "default_user_group"

--- a/octoprint_auth_ldap/ldap.py
+++ b/octoprint_auth_ldap/ldap.py
@@ -4,9 +4,10 @@ from __future__ import absolute_import
 import json
 
 import ldap
-from octoprint_auth_ldap.constants import AUTH_PASSWORD, AUTH_USER, DISTINGUISHED_NAME, OU, OU_FILTER, OU_MEMBER_FILTER, \
+from octoprint_auth_ldap.constants import AUTH_PASSWORD, AUTH_PASSWORD_FILE, AUTH_USER, DISTINGUISHED_NAME, OU, OU_FILTER, OU_MEMBER_FILTER, \
     REQUEST_TLS_CERT, SEARCH_BASE, URI
 from octoprint_auth_ldap.tweaks import DependentOnSettingsPlugin
+from pathlib import Path
 
 
 class LDAPConnection(DependentOnSettingsPlugin):
@@ -21,7 +22,8 @@ class LDAPConnection(DependentOnSettingsPlugin):
 
         if not user:
             user = self.settings.get([AUTH_USER])
-            password = self.settings.get([AUTH_PASSWORD])
+            password = self.settings.get([AUTH_PASSWORD]) or \
+                Path(self.settings.get([AUTH_PASSWORD_FILE])).read_text()
 
         try:
             self.logger.debug("Initializing LDAP connection to %s" % uri)


### PR DESCRIPTION
This allows for declaring a separate password file from the configuration file. This means the settings file can remain relatively transparent/open without leaking any secrets, and the secret file can also enjoy stricter security settings.  It may also allow for an easier time for various configuration management systems (Docker, Nix, Puppet) to lay down the secret.